### PR TITLE
Feature/gitrefs

### DIFF
--- a/archetect-core/src/actions/conditionals.rs
+++ b/archetect-core/src/actions/conditionals.rs
@@ -16,7 +16,7 @@ pub struct IfAction {
     condition: Condition,
     #[serde(rename = "then", alias = "actions")]
     then_actions: Vec<ActionId>,
-    #[serde(rename = "else")]
+    #[serde(rename = "else", skip_serializing_if = "Option::is_none")]
     else_actions: Option<Vec<ActionId>>,
 }
 

--- a/archetect-core/src/actions/set.rs
+++ b/archetect-core/src/actions/set.rs
@@ -284,7 +284,7 @@ fn prompt_for_enum(prompt: &mut String, options: &Vec<String>, default: &Option<
         eprintln!("{:>2}) {}", id + 1, option);
     }
 
-    let mut message = String::from("Select and entry: ");
+    let mut message = String::from("Select an entry: ");
     if let Some(default) = default {
         if options.contains(default) {
             message.push_str(format!("[{}] ", default).as_str());

--- a/archetect-core/src/config/catalog.rs
+++ b/archetect-core/src/config/catalog.rs
@@ -19,7 +19,7 @@ impl Catalog {
         let catalog_path = match source {
             Source::LocalFile { path } => path,
             Source::RemoteHttp { url: _, path } => path,
-            Source::RemoteGit { url: _, path } => path.join(CATALOG_FILE_NAME),
+            Source::RemoteGit { url: _, path, gitref: _ } => path.join(CATALOG_FILE_NAME),
             Source::LocalDirectory { path } => path.join(CATALOG_FILE_NAME),
         };
 

--- a/archetect-core/src/source.rs
+++ b/archetect-core/src/source.rs
@@ -238,9 +238,9 @@ fn is_branch(path: &str, gitref: &str) -> bool {
 }
 
 fn find_default_branch(path: &str) -> Result<String, SourceError> {
-    for candidate in ["develop", "main", "master"] {
+    for candidate in &["develop", "main", "master"] {
         if is_branch(path, candidate) {
-            return Ok(candidate.to_owned());
+            return Ok((*candidate).to_owned());
         }
     }
     Err(SourceError::NoDefaultBranch)

--- a/archetect-core/src/source.rs
+++ b/archetect-core/src/source.rs
@@ -295,11 +295,6 @@ mod tests {
         println!("{:?}", source);
     }
 
-    #[test]
-    fn test_ssh_git_pattern() {
-        let captures = SSH_GIT_PATTERN.captures("git@github.com:archetect/archetect-tutorial.git#02_structure");
-        println!("{:?}", captures);
-    }
     //    use super::*;
     //    use matches::assert_matches;
 

--- a/archetect-core/src/vendor/tera/mod.rs
+++ b/archetect-core/src/vendor/tera/mod.rs
@@ -1,5 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tera")]
-
 //! # Tera
 //! Tera is a template engine based on [Jinja2](http://jinja.pocoo.org/)
 //! and the [Django template language](https://docs.djangoproject.com/en/3.1/topics/templates/).


### PR DESCRIPTION
This adds the ability to specify a git ref to Archetect Git URLs.

This allows for pinning an archetype to a specific version, even if new updates are occurring on main.  Basic version management of archetypes.

Currently, if no gitref is specified, Archetect will search for a default branch named 'develop', 'main', and 'master', in that order.