### PR TITLE
Add support for headless mode

### DIFF
--- a/archetect-cli/Cargo.toml
+++ b/archetect-cli/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://archetect.github.io"
 repository = "https://github.com/archetect/archetect"
 keywords = ["code-generation", "content-generation", "jinja2", "cli"]
 readme = "../README.md"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Jimmie Fulton <jimmie.fulton@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-archetect-core = { path = "../archetect-core", version = "0.7.0" }
+archetect-core = { path = "../archetect-core", version = "0.7.1" }
 ansi_term = "0.12"
 atty = "0.2"
 clap = "2"

--- a/archetect-cli/src/cli.rs
+++ b/archetect-cli/src/cli.rs
@@ -28,7 +28,7 @@ pub fn get_matches() -> App<'static, 'static> {
         .arg(
             Arg::with_name("headless")
                 .global(true)
-                .help("Expect all variable values to be provided by answers arguments or files, never waiting for user \
+                .help("Expect all variable values to be provided by answer arguments or files, never waiting for user \
                 input.")
                 .long("headless"),
         )

--- a/archetect-cli/src/cli.rs
+++ b/archetect-cli/src/cli.rs
@@ -26,6 +26,13 @@ pub fn get_matches() -> App<'static, 'static> {
                 .long("offline"),
         )
         .arg(
+            Arg::with_name("headless")
+                .global(true)
+                .help("Expect all questions to be answered by answers arguments of files, never waiting for user \
+                input.")
+                .long("headless"),
+        )
+        .arg(
             Arg::with_name("answer")
                 .short("a")
                 .long("answer")

--- a/archetect-cli/src/cli.rs
+++ b/archetect-cli/src/cli.rs
@@ -28,7 +28,7 @@ pub fn get_matches() -> App<'static, 'static> {
         .arg(
             Arg::with_name("headless")
                 .global(true)
-                .help("Expect all questions to be answered by answers arguments of files, never waiting for user \
+                .help("Expect all variable values to be provided by answers arguments or files, never waiting for user \
                 input.")
                 .long("headless"),
         )

--- a/archetect-cli/src/main.rs
+++ b/archetect-cli/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
 fn execute(matches: ArgMatches) -> Result<(), ArchetectError> {
     let mut archetect = Archetect::builder()
         .with_offline(matches.is_present("offline"))
+        .with_headless(matches.is_present("headless"))
         .build()?;
 
     let mut answers = LinkedHashMap::new();

--- a/archetect-core/Cargo.toml
+++ b/archetect-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archetect-core"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Jimmie Fulton <jimmie.fulton@gmail.com>"]
 description = "Generates Content from Archetype Template Directories and Git Repositories."
 homepage = "https://archetect.github.io"

--- a/archetect-core/src/actions/set.rs
+++ b/archetect-core/src/actions/set.rs
@@ -38,8 +38,13 @@ pub fn populate_context(
 
         trace!("Attempting to satisfy {} ({:?})", identifier, variable_info);
 
+
+        // No answers or explict value provide.  Check to see if we're in headless mode before prompting for a value.
+        if archetect.headless() {
+            return Err(ArchetectError::HeadlessMissingAnswer(identifier.to_owned()));
+        }
         // If we've made it this far, there was not an acceptable answer or explicit value.  We need to prompt for a
-        // valid value
+        // valid value.
         let mut prompt = if let Some(prompt) = variable_info.prompt() {
             format!("{} ", archetect.render_string(prompt.trim(), context)?)
         } else {

--- a/archetect-core/src/actions/set.rs
+++ b/archetect-core/src/actions/set.rs
@@ -39,12 +39,12 @@ pub fn populate_context(
         trace!("Attempting to satisfy {} ({:?})", identifier, variable_info);
 
 
-        // No answers or explict value provide.  Check to see if we're in headless mode before prompting for a value.
+        // No answer or explict value provided.  Check to see if we're in headless mode before prompting for a value.
         if archetect.headless() {
             return Err(ArchetectError::HeadlessMissingAnswer(identifier.to_owned()));
         }
-        // If we've made it this far, there was not an acceptable answer or explicit value.  We need to prompt for a
-        // valid value.
+        // If we've made it this far, there was not an acceptable answer or explicit value provided.  We need to prompt
+        // for a valid value.
         let mut prompt = if let Some(prompt) = variable_info.prompt() {
             format!("{} ", archetect.render_string(prompt.trim(), context)?)
         } else {

--- a/archetect-core/src/core.rs
+++ b/archetect-core/src/core.rs
@@ -21,6 +21,7 @@ pub struct Archetect {
     tera: Tera,
     paths: Rc<Box<dyn SystemLayout>>,
     offline: bool,
+    headless: bool,
     switches: HashSet<String>,
 }
 
@@ -31,6 +32,10 @@ impl Archetect {
 
     pub fn offline(&self) -> bool {
         self.offline
+    }
+
+    pub fn headless(&self) -> bool {
+        self.headless
     }
 
     pub fn builder() -> ArchetectBuilder {
@@ -193,6 +198,7 @@ impl Archetect {
 pub struct ArchetectBuilder {
     layout: Option<Box<dyn SystemLayout>>,
     offline: bool,
+    headless: bool,
     switches: HashSet<String>,
 }
 
@@ -201,6 +207,7 @@ impl ArchetectBuilder {
         ArchetectBuilder {
             layout: None,
             offline: false,
+            headless: false,
             switches: HashSet::new(),
         }
     }
@@ -214,6 +221,7 @@ impl ArchetectBuilder {
             tera: crate::vendor::tera::extensions::create_tera(),
             paths,
             offline: self.offline,
+            headless: self.headless,
             switches: self.switches,
         })
     }
@@ -234,6 +242,11 @@ impl ArchetectBuilder {
 
     pub fn with_offline(mut self, offline: bool) -> ArchetectBuilder {
         self.offline = offline;
+        self
+    }
+
+    pub fn with_headless(mut self, headless: bool) -> ArchetectBuilder {
+        self.headless = headless;
         self
     }
 }

--- a/archetect-core/src/errors.rs
+++ b/archetect-core/src/errors.rs
@@ -22,7 +22,8 @@ pub enum ArchetectError {
     CatalogError(#[from] CatalogError),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
-    #[error("Headless mode requires answers to be supplied for all variables, but `{0}` was not.")]
+    #[error("Headless mode requires answers to be supplied for all variables, but no answer was supplied for the `{0}` \
+    variable.")]
     HeadlessMissingAnswer(String),
 }
 

--- a/archetect-core/src/errors.rs
+++ b/archetect-core/src/errors.rs
@@ -22,6 +22,8 @@ pub enum ArchetectError {
     CatalogError(#[from] CatalogError),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    #[error("Headless mode requires answers to be supplied for all variables, but `{0}` was not.")]
+    HeadlessMissingAnswer(String),
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Add support for 'headless' mode.

With this mode, if there are variables that are not explicitly set, or answered by answer parameters or files, do not prompt.  Instead, provide an error message.  The prevents CI jobs from hanging indefinitely.